### PR TITLE
Conditional fix for new row

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -107,7 +107,7 @@ function upsert(kind, row) {
 
   var found = false;
 
-  if (row.id) {
+  if (! _.isUndefined(row.id)) {
     entity.rows = entity.rows.map(function(innerRow) {
       if (innerRow.id === row.id) {
         found = true;


### PR DESCRIPTION
Changes the conditional to check if `row.id` is undefined to fix the case when the `row.id` passed in is 0 (creates a new list otherwise).
